### PR TITLE
feat: atualizar margens para preenchimento no cabeçalho

### DIFF
--- a/components/layout/header/header.module.scss
+++ b/components/layout/header/header.module.scss
@@ -9,7 +9,7 @@ $md-screen: 768px;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin: 10px 80px;
+    padding: 10px 80px;
     .logo {
       display: flex;
       align-items: center;
@@ -40,7 +40,7 @@ $md-screen: 768px;
   
   @media screen and (max-width: $md-screen) {
     .header {
-      margin: 10px 24px;
+      padding: 10px 24px;
       .logo {
         img {
           width: 80px;


### PR DESCRIPTION
Vamos preferir por usar padding no header:
![image](https://github.com/jordyfontoura/coopera-frontend/assets/52868800/5c259362-335c-422c-a1b9-29286999c1a6)
Solução:
![image](https://github.com/jordyfontoura/coopera-frontend/assets/52868800/218af688-b4b0-4479-99a5-cfe141139543)
